### PR TITLE
to make file added: lint, format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,13 @@ TST_SRCS = \
 
 .PHONY: all build test rebuild clean
 
-all: clean build test 
+all: clean format build test 
 
+lint:
+	clang-tidy $(SRCS) $(HDRS) -format-style='{BasedOnStyle: google}' -checks='-*,readability-*,modernize-*,-modernize-use-trailing-return-type,performance-*,cppcoreguidelines-*,clang-analyzer-*,bugprone-*,misc-*,-bugprone-easily-swappable-parameters' -- -std=c++17 -I$(HDRS)
+
+format:
+	clang-format -style=google -i $(SRCS) $(HDRS)*.hpp
 
 build: $(TARGET)
 


### PR DESCRIPTION
Использовал в качестве линтера clang-tidy, а в качестве форматтера - clang-format. За стиль взял [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html). Из настроек указал этот стиль, а в линтере поставил проверки того, что посчитал нужным, и убрал некоторые из них, которые я посчитал излишними.